### PR TITLE
correct admin_id type casting to string, update README, fix duplicates in intercom_contact_enhanced

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ vars:
     company_history_pass_through_columns: [company_custom_field_1, company_custom_field_2]
     contact_history_pass_through_columns: [contact_custom_column]
 ```
-This package assumes that you use Intercom's `company tag`, `contact tag`, `contact company`, and `conversation tag`, `team` and `team admin` mapping tables. If you do not use these tables, add the configuration below to your `dbt_project.yml`. By default, these variables are set to `True`:
+This package assumes that you use Intercom's `company tag`, `contact tag`, `contact company`, and `conversation tag`, `team` and `team admin` mapping tables. If you do not use these tables, add the configuration below to your `dbt_project.yml`. Since the Intercom package relies on the Intercom Source package, you  will need to  set the variables as False for both packages. By default, these variables are set to `True`.:
 
 ```yml
 # dbt_project.yml
@@ -63,6 +63,12 @@ This package assumes that you use Intercom's `company tag`, `contact tag`, `cont
 ...
 vars:
   intercom_source:
+    using_contact_company: False
+    using_company_tags: False
+    using_contact_tags: False
+    using_conversation_tags: False
+    using_team: False
+  intercom:
     using_contact_company: False
     using_company_tags: False
     using_contact_tags: False

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ vars:
     company_history_pass_through_columns: [company_custom_field_1, company_custom_field_2]
     contact_history_pass_through_columns: [contact_custom_column]
 ```
-This package assumes that you use Intercom's `company tag`, `contact tag`, `contact company`, and `conversation tag`, `team` and `team admin` mapping tables. If you do not use these tables, add the configuration below to your `dbt_project.yml`. Since the Intercom package relies on the Intercom Source package, you  will need to  set the variables as False for both packages. By default, these variables are set to `True`.:
+This package assumes that you use Intercom's `company tag`, `contact tag`, `contact company`, and `conversation tag`, `team` and `team admin` mapping tables. If you do not use these tables, add the configuration below to your `dbt_project.yml`. Since the Intercom package relies on the Intercom Source package, you  will need to  set the variables as False for both packages. By default, these variables are set to `True`:
 
 ```yml
 # dbt_project.yml

--- a/models/intercom__contact_enhanced.sql
+++ b/models/intercom__contact_enhanced.sql
@@ -1,7 +1,17 @@
+--take latest contact history to get the last update for the contact
 with contact_history as (
-  select *
+  select
+  *,
+  row_number() over (partition by contact_id order by updated_at desc) as rank_latest_contact_update
   from {{ ref('stg_intercom__contact_history') }}
 ),
+
+contact_latest as (
+  select
+  * except (rank_latest_contact_update)
+  from contact_history
+  where rank_latest_contact_update = 1
+)
 
 --If you use the contact company table this will be included, if not it will be ignored.
 {% if var('using_contact_company', True) %}
@@ -31,12 +41,12 @@ tags as (
 --Aggregates the tags associated with a single contact into an array.
 contact_tags_aggregate as (
   select
-    contact_history.contact_id,
+    contact_latest.contact_id,
     {{ fivetran_utils.string_agg('tags.name', "', '" ) }} as all_contact_tags
-  from contact_history
+  from contact_latest
 
   left join contact_tags
-      on contact_tags.contact_id = contact_history.contact_id
+      on contact_tags.contact_id = contact_latest.contact_id
     
     left join tags
       on tags.tag_id = contact_tags.tag_id
@@ -49,7 +59,7 @@ contact_tags_aggregate as (
 {% if var('using_contact_company', True) %}
 contact_company_array as (
   select
-    contact_history.contact_id,
+    contact_latest.contact_id,
     {{ fivetran_utils.string_agg('company_history.company_name', "', '" ) }} as all_contact_company_names
 
   from contact_history
@@ -67,7 +77,7 @@ contact_company_array as (
 --Joins the contact table with tags (if used) as well as the contact company (if used).
 final as (
   select
-    contact_history.*
+    contact_latest.*
         
     --If you use contact tags this will be included, if not it will be ignored.
     {% if var('using_contact_tags', True) %}
@@ -79,18 +89,18 @@ final as (
     ,contact_company_array.all_contact_company_names
     {% endif %}
 
-  from contact_history
+  from contact_latest
 
   --If you use the contact company table this will be included, if not it will be ignored.
   {% if var('using_contact_company', True) %}
   left join contact_company_array
-    on contact_company_array.contact_id = contact_history.contact_id
+    on contact_company_array.contact_id = contact_latest.contact_id
   {% endif %}
 
   --If you use the contact tags table this will be included, if not it will be ignored.
   {% if var('using_contact_tags', True) %}
   left join contact_tags_aggregate
-      on contact_tags_aggregate.contact_id = contact_history.contact_id
+      on contact_tags_aggregate.contact_id = contact_latest.contact_id
   {% endif %}
 )
 

--- a/models/intercom__contact_enhanced.sql
+++ b/models/intercom__contact_enhanced.sql
@@ -11,7 +11,7 @@ contact_latest as (
   * except (rank_latest_contact_update)
   from contact_history
   where rank_latest_contact_update = 1
-)
+),
 
 --If you use the contact company table this will be included, if not it will be ignored.
 {% if var('using_contact_company', True) %}

--- a/models/intermediate/int_intercom__conversation_part_events.sql
+++ b/models/intermediate/int_intercom__conversation_part_events.sql
@@ -33,8 +33,8 @@ conversation_contact_events as (
 final as (
     select distinct
         conversation_part_history.conversation_id,
-        cast(conversation_admin_events.first_close_by_admin_id as {{ dbt_utils.type_int() }}) as first_close_by_admin_id,
-        cast(conversation_admin_events.last_close_by_admin_id as {{ dbt_utils.type_int() }}) as last_close_by_admin_id,
+        cast(conversation_admin_events.first_close_by_admin_id as {{ dbt_utils.type_string() }}) as first_close_by_admin_id,
+        cast(conversation_admin_events.last_close_by_admin_id as {{ dbt_utils.type_string() }}) as last_close_by_admin_id,
         cast(conversation_contact_events.first_contact_author_id as {{ dbt_utils.type_string() }}) as first_contact_author_id,
         cast(conversation_contact_events.last_contact_author_id as {{ dbt_utils.type_string() }}) as last_contact_author_id,
         conversation_admin_events.first_close_at,

--- a/packages.yml
+++ b/packages.yml
@@ -1,5 +1,3 @@
 packages:
-  - git: "https://github.com/robertpknight/dbt_intercom_source.git"
-    revision: master
-  # - package: fivetran/intercom_source
-  #   version: 0.1.1
+  - package: fivetran/intercom_source
+    version: 0.1.1

--- a/packages.yml
+++ b/packages.yml
@@ -1,3 +1,5 @@
 packages:
-  - package: fivetran/intercom_source
-    version: 0.1.1
+  - git: "https://github.com/robertpknight/dbt_intercom_source.git"
+    revision: master
+  # - package: fivetran/intercom_source
+  #   version: 0.1.1


### PR DESCRIPTION
`intercom__admin_metrics` was failing due to the incorrect casting of an admin_id:

`Database Error in model intercom__admin_metrics (models/intercom__admin_metrics.sql)
  No matching signature for operator = for argument types: INT64, STRING. Supported signature: ANY = ANY at [105:12]
  compiled SQL at target/run/intercom/models/intercom__admin_metrics.sql`

This PR corrects that casting. It also updates the README about which vars need to be included in the dbt_project file. This was out of date and might cause confusion for a less experience user of the package.

This PR also fixes duplicates in `intercom_contact_enhanced` caused by not taking the latest update from contact history. This leads to duplicates and causes a failing test. By taking the latest update we ensure singular rows for each contact.

This PR is related to: https://github.com/fivetran/dbt_intercom_source/pull/5/files