### PR TITLE
Add distinct clause in the listagg function

### DIFF
--- a/models/intercom__contact_enhanced.sql
+++ b/models/intercom__contact_enhanced.sql
@@ -51,7 +51,7 @@ contact_tags_aggregate as (
 contact_company_array as (
   select
     contact_latest.contact_id,
-    {{ fivetran_utils.string_agg('company_history.company_name', "', '" ) }} as all_contact_company_names
+    {{ fivetran_utils.string_agg('distinct company_history.company_name', "', '" ) }} as all_contact_company_names
 
   from contact_latest
   


### PR DESCRIPTION
This PR is created to pass the extra clause to the LISTAGG function in order to avoid trying to aggregate duplicate company names from company history table. Without this clause the function would cause the result to exceed LIST agg limit.